### PR TITLE
Piper/functional expression shape checking utilities

### DIFF
--- a/vyper/parser/validation.py
+++ b/vyper/parser/validation.py
@@ -1,0 +1,235 @@
+import ast
+import functools
+import operator
+
+from vyper.types import (
+    BaseType,
+)
+
+from .expr import (
+    Expr
+)
+
+
+def _check_all(value, checker_fns):
+    return all(
+        fn(value)
+        for fn
+        in checker_fns
+    )
+
+
+def check_all(*checker_fns):
+    return functools.partial(_check_all, checker_fns=checker_fns)
+
+
+def _check_any(value, checker_fns):
+    return any(
+        fn(value)
+        for fn
+        in checker_fns
+    )
+
+
+def check_any(*checker_fns):
+    return functools.partial(_check_any, checker_fns=checker_fns)
+
+
+def is_ast_for(value):
+    return isinstance(value, ast.For)
+
+
+def is_ast_call(value):
+    return isinstance(value, ast.Call)
+
+
+def is_ast_name(value):
+    return isinstance(value, ast.Name)
+
+
+def _check_attr(value, attr, check_fn):
+    try:
+        value_attr = getattr(value, attr)
+    except AttributeError:
+        return False
+    else:
+        return check_fn(value_attr)
+
+
+def check_attr(attr, check_fn):
+    return functools.partial(_check_attr, attr=attr, check_fn=check_fn)
+
+
+def check_nested_attr(attrs, check_fn):
+    if not attrs:
+        raise ValueError("Must provide at least one attribute")
+    return functools.reduce(
+        lambda fn, attr: check_attr(attr, fn),
+        reversed(attrs),
+        check_fn,
+    )
+
+
+def apply_transform(transform_fn):
+    def outer(fn):
+        @functools.wraps(fn)
+        def inner(value):
+            return fn(transform_fn(value))
+        return inner
+    return outer
+
+
+def check_in(seq):
+    return functools.partial(operator.contains, seq)
+
+
+def check_equals(other):
+    return functools.partial(operator.eq, other)
+
+
+def is_ast_binop(value):
+    return isinstance(value, ast.BinOp)
+
+
+def is_ast_binop_add(value):
+    return is_ast_binop(value) and isinstance(value.op, ast.Add)
+
+
+def _is_expr_basetype(value, context):
+    expr = Expr.parse_value_expr(value, context)
+    return isinstance(expr.type, BaseType)
+
+
+def is_expr_basetype(context):
+    return functools.partial(_is_expr_basetype, context=context)
+
+
+def _is_expr_literal(value, context):
+    expr = Expr.parse_value_expr(value, context)
+    return expr.is_literal
+
+
+def is_expr_literal(context):
+    return functools.partial(_is_expr_literal, context=context)
+
+
+def _is_expr_of_type(value, context, _type):
+    expr = Expr.parse_value_expr(value, context)
+    return expr.type == _type
+
+
+def check_expr_type_is_uint256(context):
+    return functools.partial(_is_expr_of_type, context=context, _type='uint256')
+
+
+def check_expr_type_is_int256(context):
+    return functools.partial(_is_expr_of_type, context=context, _type='uint256')
+
+
+def check_length_equal(length):
+    return apply_transform(len)(check_equals(length))
+
+
+is_for_in_range_stmt = check_all(
+    is_ast_for,
+    check_attr('iter', is_ast_call),
+    check_nested_attr(('iter', 'func'), is_ast_name),
+    check_attr('target', is_ast_name),
+    check_nested_attr(('iter', 'func', 'id'), check_equals('range')),
+    check_nested_attr(('iter', 'args'), apply_transform(len)(check_in({1, 2}))),
+)
+
+
+def is_expr_literal_integer(value, context):
+    return check_all(
+        is_expr_basetype(context),
+        is_expr_literal(context),
+        check_any(
+            check_expr_type_is_uint256,
+            check_expr_type_is_int256,
+        ),
+    )
+
+
+def is_expr_non_literal_integer(value, context):
+    return check_all(
+        is_expr_basetype(context),
+        is_expr_literal(context),
+        check_any(
+            check_expr_type_is_uint256,
+            check_expr_type_is_int256,
+        ),
+    )
+
+
+def is_expr_any_integer(value, context):
+    return check_all(
+        is_expr_basetype(context),
+        check_any(
+            check_expr_type_is_uint256,
+            check_expr_type_is_int256,
+        ),
+    )
+
+
+def _check_value_at_index(items, index, check_fn):
+    try:
+        value = items[index]
+    except IndexError:
+        return False
+    else:
+        return check_fn(value)
+
+
+def check_value_at_index(index, check_fn):
+    return functools.partial(_check_value_at_index, index=index, check_fn=check_fn)
+
+
+def is_range_with_one_integer_value(value, context):
+    return check_all(
+        check_nested_attr(('iter', 'args'), check_length_equal(1)),
+        check_nested_attr(('iter', 'args'), check_value_at_index(1, functools.partial(is_expr_any_integer, context=context))),
+    )
+
+
+def is_range_with_two_integer_values(value, context):
+    return check_all(
+        check_nested_attr(('iter', 'args'), check_length_equal(2)),
+        check_nested_attr(('iter', 'args'), check_value_at_index(1, functools.partial(is_expr_any_integer, context=context))),
+        check_nested_attr(('iter', 'args'), check_value_at_index(2, functools.partial(is_expr_any_integer, context=context))),
+    )
+
+
+def is_for_with_constant():
+    # Type 1 for, e.g. for i in range(10): ...
+    if num_of_args == 1:
+        arg0_val = self._get_range_const_value(arg0)
+        start = LLLnode.from_list(0, typ='int128', pos=getpos(self.stmt))
+        rounds = arg0_val
+
+def is_for_with_two_valid_args():
+    arg1 = self.stmt.iter.args[1]
+    if not isinstance(arg1, ast.BinOp) or not isinstance(arg1.op, ast.Add):
+        raise StructureException(
+            (
+                "Two-arg for statements must be of the form `for i "
+                "in range(start, start + rounds): ...`"
+            ),
+            arg1,
+        )
+
+    if ast.dump(arg0) != ast.dump(arg1.left):
+        raise StructureException(
+            (
+                "Two-arg for statements of the form `for i in "
+                "range(x, x + y): ...` must have x identical in both "
+                "places: %r %r"
+            ) % (
+                ast.dump(arg0),
+                ast.dump(arg1.left)
+            ),
+            self.stmt.iter,
+        )
+
+    rounds = self._get_range_const_value(arg1.right)
+    start = Expr.parse_value_expr(arg0, self.context)


### PR DESCRIPTION
PR is meant to be demonstrative of an idea I had.  Working my way through the codebase I've found a lot of sections like this:

https://github.com/ethereum/vyper/blob/e83d4b6d0b2c74d4dead2b0c402677f9d200cd6f/vyper/parser/stmt.py#L377-L381

Repeated `isinstance` checks that incrementally validate the structure of an AST node.

The *problem* that I see is that these checks are verbose, and often require checking 3+ things, often in a nested manner such that you can't check the later ones until you've validated the earlier ones because you might end up accessing invalid properties if the AST is malformed for some reason (like accessing the `func.id` for an AST node that doesn't have this property.

So I thought, can we bake these concepts into composable primatives.  Here's a branch that tries to demonstrate these.  I tried applying them to the `if/elif/else` that handles `for ... in range(...)` but realized that I still don't quite know enough about the intended behavior to muck with the actual functionality.

### The basics

Lots of primitives written in the form of small functions that do one thing such as:

- check if something is an instance of `ast.Name`
- check is something equals some value A
- check if something has a length of X

Then, some primatives that allow for you to apply these to data structures.  For some `check_fn` like the ones above:

- return the result of applying the `check_fn` to the attribute denoted by `attr`.
  - `check_attr('iter', is_ast_call)(value)` is equivalent to `is_ast_call(value.iter)`
- return the result of applying the `check_fn` to the value an index in a sequence denoted by `index`.
  - `check_at_index(0, is_ast_call)(args)` is equivalent to `is_ast_call(args[0])`

Then, some primitives that allow you to combine these checks using logical `and` or `or` concepts.

- return whether all of the check functions `fn1, fn2, fn3` pass.
  - `check_all(is_ast_call, check_attr('args', check_length(1)))` is equivalent to `is_ast_call(value) and check_length(1)(value.args)`

### Why might this be good?

Well, I'm not 100% sure it is, but I think it could be.  Here's my attempt at an objective assessment

#### The good

- functional approach usually results in it being easier to reason about (once you're familiar with the tools).
- composable: allowing us to write each check we need to do once and re-use it in many places.
- expressive: allows concise expression of complex validation rules.  Code using this validation should be cleaner to read and understand.
- readability: because these make it easy to bundle complex logic into a single statement the code for the various parsers should shrink, resulting in the code being more delineated into high level and low level bits, which *should* result in better readability if used correctly.

#### The downside

The primary downside I see is it being harder to debug when something is broken.  

When one of these composed check functions is not doing what it is intended, it is very opaque as to why.  This can be mitigated but by the nature of this approach, we would be hiding the complexity inside of these utilities and it can be harder introspect because of this.

We can mitigate the opaquness of failures by embedding logging statements into this API to allow verbose dumps of what logic was applied and what passed and failed.  There are alternate ways to do this other than logging, but they will all likely take a similar form of making introspection of the individual logic functions easier to dig into.